### PR TITLE
스케줄 생성 시 작성자 이름 추가 및 페이지네이션 기능 업데이트

### DIFF
--- a/src/main/java/com/example/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedule/controller/ScheduleController.java
@@ -3,6 +3,7 @@ package com.example.schedule.controller;
 import com.example.schedule.dto.schedule.ScheduleRequestDto;
 import com.example.schedule.dto.schedule.ScheduleResponseDto;
 import com.example.schedule.service.schedule.ScheduleService;
+import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,12 +22,18 @@ public class ScheduleController {
     }
 
     @PostMapping
-    public ResponseEntity<ScheduleResponseDto> createSchedule (@RequestBody ScheduleRequestDto dto) {
+    public ResponseEntity<ScheduleResponseDto> createSchedule(@RequestBody ScheduleRequestDto dto) {
         return new ResponseEntity<>(scheduleService.createSchedule(dto), HttpStatus.OK);
     }
 
+    @GetMapping("/pageNum/{pageNum}/pageSize/{pageSize}")
+    public List<ScheduleResponseDto> pagination(@PathVariable int pageNum, @PathVariable int pageSize) {
+        return scheduleService.pagination(pageNum, pageSize);
+    }
+
+
     @GetMapping
-    public List<ScheduleResponseDto> findAllSchedules () {
+    public List<ScheduleResponseDto> findAllSchedules() {
         return scheduleService.findAllSchedules();
     }
 
@@ -47,8 +54,8 @@ public class ScheduleController {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteSchedule(@PathVariable int id, @RequestBody ScheduleRequestDto dto) {
-        scheduleService.deleteSchedule(id,dto.getUser_uid());
-        return new ResponseEntity<>( HttpStatus.OK);
+        scheduleService.deleteSchedule(id, dto.getUser_uid());
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/example/schedule/dto/schedule/ScheduleRequestDto.java
+++ b/src/main/java/com/example/schedule/dto/schedule/ScheduleRequestDto.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ScheduleRequestDto {
     private String user_uid;
+    private String user_name;
     private String title;
     private String content;
     private String color;

--- a/src/main/java/com/example/schedule/repository/schedule/JdbcTemplateScheduleRepository.java
+++ b/src/main/java/com/example/schedule/repository/schedule/JdbcTemplateScheduleRepository.java
@@ -29,7 +29,7 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository{
     public int createSchedule(ScheduleRequestDto dto) {
 
         String query = "INSERT INTO schedule (user_uid,name, title, content, color, create_date, update_date) " +
-                "VALUES (?,?,?,?,?,CURRENT_DATE(),CURRENT_DATE())";
+                "VALUES (?,?,?,?,?,CURRENT_TIMESTAMP(),CURRENT_TIMESTAMP())";
 
         return jdbcTemplate.update(query, dto.getUser_uid(),dto.getUser_name(), dto.getTitle(), dto.getContent(), dto.getColor());
     }
@@ -81,6 +81,13 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository{
     public int deleteScheduleTitle(int id) {
         return jdbcTemplate.update("DELETE FROM schedule WHERE id = ?", id);
     }
+
+    @Override
+    public List<ScheduleResponseDto> findFirstPageSchedules(int pageNum, int pageSize) {
+        return jdbcTemplate.query("SELECT * FROM schedule ORDER BY update_date DESC, id LIMIT ?,?", scheduleRowMapper(),(pageNum-1)*pageSize, pageSize);
+
+    }
+
 
     //TODO 전체 다 반환? 고민해볼것
     private RowMapper<ScheduleResponseDto> scheduleRowMapper () {

--- a/src/main/java/com/example/schedule/repository/schedule/JdbcTemplateScheduleRepository.java
+++ b/src/main/java/com/example/schedule/repository/schedule/JdbcTemplateScheduleRepository.java
@@ -28,10 +28,10 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository{
     @Override
     public int createSchedule(ScheduleRequestDto dto) {
 
-        String query = "INSERT INTO schedule (user_uid, title, content, color, create_date, update_date) " +
-                "VALUES (?,?,?,?,CURRENT_DATE(),CURRENT_DATE())";
+        String query = "INSERT INTO schedule (user_uid,name, title, content, color, create_date, update_date) " +
+                "VALUES (?,?,?,?,?,CURRENT_DATE(),CURRENT_DATE())";
 
-        return jdbcTemplate.update(query, dto.getUser_uid(), dto.getTitle(), dto.getContent(), dto.getColor());
+        return jdbcTemplate.update(query, dto.getUser_uid(),dto.getUser_name(), dto.getTitle(), dto.getContent(), dto.getColor());
     }
 
     @Override

--- a/src/main/java/com/example/schedule/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/example/schedule/repository/schedule/ScheduleRepository.java
@@ -19,4 +19,6 @@ public interface ScheduleRepository {
     int updateScheduleTitle(int id, ScheduleRequestDto dto);
 
     int deleteScheduleTitle(int id);
+
+    List<ScheduleResponseDto> findFirstPageSchedules(int pageNum, int pageSize);
 }

--- a/src/main/java/com/example/schedule/service/schedule/ScheduleService.java
+++ b/src/main/java/com/example/schedule/service/schedule/ScheduleService.java
@@ -17,4 +17,6 @@ public interface ScheduleService {
     ScheduleResponseDto updateSchedulePart(int id, ScheduleRequestDto dto);
 
     void deleteSchedule(int id, String userUid);
+
+    List<ScheduleResponseDto> pagination(int pageNum, int pageSize);
 }

--- a/src/main/java/com/example/schedule/service/schedule/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/schedule/service/schedule/ScheduleServiceImpl.java
@@ -110,4 +110,17 @@ public class ScheduleServiceImpl implements ScheduleService {
             throw  new ResponseStatusException(HttpStatus.NOT_FOUND, "스케쥴이 없습니다");
         }
     }
+
+    @Override
+    public List<ScheduleResponseDto> pagination(int pageNum, int pageSize) {
+
+        int scheduleSize =  findAllSchedules().size();
+
+//        if (pageNum > Math.ceil(scheduleSize/(double)pageSize)) {
+//            throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
+//        }
+
+
+        return scheduleRepository.findFirstPageSchedules(pageNum,pageSize);
+    }
 }


### PR DESCRIPTION
fix: 스케쥴 생성 시, 작성자 이름 추가, 
- create_date, update_date: date -> timestamp 재변경 => 초단위로 정렬 해주기 위함
- 작성자 이름 추가 -> 요구사항에 따른 추가

update: 스케쥴 페이지네이션 기능 추가
- 페이지 넘버, 페이지 사이즈를 받고 그에 맞는 스케쥴 배열을 반환
